### PR TITLE
fix some bugs in responses

### DIFF
--- a/templatex/preamble.tex
+++ b/templatex/preamble.tex
@@ -61,8 +61,9 @@
 \usepackage{multirow}
 \usepackage{psfrag}
 \usepackage{url}
-\usepackage[colorlinks,citecolor=blue]{hyperref}
-%\usepackage{hyperref}
+% \usepackage[colorlinks,citecolor=blue]{hyperref}
+\PassOptionsToPackage{colorlinks,citecolor=blue}{hyperref}
+\usepackage{hyperref}
 %\usepackage[colorlinks]{hyperref}
 %\usepackage{cite}
 \usepackage{cleveref}

--- a/templatex/responses.tex
+++ b/templatex/responses.tex
@@ -15,7 +15,8 @@
 \excludecomment{TulipStyle}
 %
 %=================================================================
-\include{preamble}
+\input{preamble}
+\usepackage[numbers]{natbib}
 \usepackage{multirow, makecell,tabularx}
 \usepackage{tikz}
 \usepackage{bbding}
@@ -60,7 +61,7 @@ The reviewers agree that the topic of the paper is interesting. There are howeve
 
 \AR 
 Thanks for your concern.
-In this revision, 
+In this revision~\citep{BJL11J01}, 
 we have xxx
 
 
@@ -117,9 +118,9 @@ including recent references on XXX ecosystem:
 
 %[28] F. M. Awaysheh, M. Alazab, M. Gupta, T. F. Pena, and J. C. Cabaleiro, “Next-generation big data federation access control: A reference model,” Future Generation Computer Systems, 2020.
 
-%\bibliography{tuliplab,yourbib}
-%% TODO: you should change this yourbib into a proper bib file name
-%\bibliographystyle{plainnat}
+\bibliography{tuliplab,yourbib}
+% TODO: you should change this yourbib into a proper bib file name
+\bibliographystyle{plainnat}
 
 %\begin{bibunit}[plain]
 %	\nocite{BJL11J01,BL12J01}


### PR DESCRIPTION
First,  when we use '\include{preamble}', we will receive a warning, that is 'LaTeX: \ include should only be used after \ start {document}.' It has been fixed by using the '\input{preamble}'. 

Second, we are missing the command \ usepackage [numbers] {natbib}. Despite we add it in the 'preamble.tex' file, it is used in 'TulipStyle'. In 'response.tex', the 'TulipStyle'  is excluded. Thus, we have added '\usepackage[numbers]{natbib}' into 'response.tex'

Third, the '% \usepackage[colorlinks,citecolor=blue]{hyperref}' used in preamble.tex caused an error ’Option clash for package hyperref‘ when we compile response.tex. It can be fixed by using '\PassOptionsToPackage{colorlinks,citecolor=blue}{hyperref}
\usepackage{hyperref}'