### PR TITLE
Merge Slidev 0.1.0 release back to develop

### DIFF
--- a/slidev/README.md
+++ b/slidev/README.md
@@ -11,7 +11,7 @@ This workspace develops the reusable Slidev system for TULIP Lab courses and tal
 - `templates/`: private source templates used by the project creator
 - `examples/`: private Course, Talk, and layout examples
 
-The four public packages currently share the prerelease version `0.1.0-beta.1`. They can be packed and tested locally, but have not been published.
+The four public packages share the stable version `0.1.0`.
 
 ## Development
 
@@ -24,7 +24,7 @@ pnpm check
 
 ## Version Policy
 
-- Theme, addon, checker, and creator move together during the initial beta release train.
+- Theme, addon, checker, and creator move together during the initial release train.
 - Consumer projects pin exact package versions and keep independent lockfiles.
 - Stable `0.1.0` requires successful AgenticAI Course migration, the first real Talk, and `slides-deploy` integration.
 - Publishing, tagging, and deployment require an explicit release approval.

--- a/slidev/packages/create-tulip-slides/README.md
+++ b/slidev/packages/create-tulip-slides/README.md
@@ -7,13 +7,13 @@ Project creator for TULIP Slidev courses and talks.
 Create a Talk:
 
 ```sh
-pnpm dlx create-tulip-slides@0.1.0-beta.1 talk walking-and-working-with-ai
+pnpm dlx create-tulip-slides@0.1.0 talk walking-and-working-with-ai
 ```
 
 Create a Course:
 
 ```sh
-pnpm dlx create-tulip-slides@0.1.0-beta.1 course agentic-ai
+pnpm dlx create-tulip-slides@0.1.0 course agentic-ai
 ```
 
 The command is non-interactive and writes only to a new or empty target directory. Generated projects pin exact versions of Slidev, Vue, the TULIP Theme, and the checker. Course projects also include the live audience addon; Talk projects do not include it by default.

--- a/slidev/packages/create-tulip-slides/package.json
+++ b/slidev/packages/create-tulip-slides/package.json
@@ -1,9 +1,18 @@
 {
   "name": "create-tulip-slides",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "Create TULIP Slidev Course and Talk projects.",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tulip-lab/templatex.git",
+    "directory": "slidev/packages/create-tulip-slides"
+  },
+  "bugs": {
+    "url": "https://github.com/tulip-lab/templatex/issues"
+  },
+  "homepage": "https://github.com/tulip-lab/templatex/tree/main/slidev/packages/create-tulip-slides",
   "bin": {
     "create-tulip-slides": "./bin/create-tulip-slides.mjs"
   },

--- a/slidev/packages/create-tulip-slides/src/create-project.mjs
+++ b/slidev/packages/create-tulip-slides/src/create-project.mjs
@@ -3,9 +3,9 @@ import { basename, join, resolve } from 'node:path'
 
 export const PACKAGE_VERSIONS = Object.freeze({
   '@slidev/cli': '52.19.0',
-  'slidev-addon-tulip-live': '0.1.0-beta.1',
-  'slidev-theme-tulip-lab': '0.1.0-beta.1',
-  'tulip-slidev-check': '0.1.0-beta.1',
+  'slidev-addon-tulip-live': '0.1.0',
+  'slidev-theme-tulip-lab': '0.1.0',
+  'tulip-slidev-check': '0.1.0',
   'vue': '3.5.41',
 })
 

--- a/slidev/packages/slidev-addon-tulip-live/README.md
+++ b/slidev/packages/slidev-addon-tulip-live/README.md
@@ -2,7 +2,7 @@
 
 Optional live audience synchronization for TULIP Slidev presentations.
 
-This package is under active migration and has not been published. It mounts the synchronization bridge through its own Slidev global layer, independently of the visual Theme.
+Install the exact stable release with `pnpm add slidev-addon-tulip-live@0.1.0`. It mounts the synchronization bridge through its own Slidev global layer, independently of the visual Theme.
 
 Enable it in deck headmatter:
 

--- a/slidev/packages/slidev-addon-tulip-live/package.json
+++ b/slidev/packages/slidev-addon-tulip-live/package.json
@@ -1,9 +1,18 @@
 {
   "name": "slidev-addon-tulip-live",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "Optional live audience synchronization for TULIP Slidev presentations.",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tulip-lab/templatex.git",
+    "directory": "slidev/packages/slidev-addon-tulip-live"
+  },
+  "bugs": {
+    "url": "https://github.com/tulip-lab/templatex/issues"
+  },
+  "homepage": "https://github.com/tulip-lab/templatex/tree/main/slidev/packages/slidev-addon-tulip-live",
   "files": [
     "components",
     "global-top.vue",

--- a/slidev/packages/slidev-theme-tulip-lab/README.md
+++ b/slidev/packages/slidev-theme-tulip-lab/README.md
@@ -2,7 +2,7 @@
 
 TULIP Lab's shared 16:10 Slidev Theme for courses and talks. It provides the branded Cover, navigation shell, table of contents, section pages, references, contact page, QR code, and reusable content layouts.
 
-This package is under active migration and has not been published.
+Install the exact stable release with `pnpm add slidev-theme-tulip-lab@0.1.0`.
 
 Workspace projects can use it with:
 

--- a/slidev/packages/slidev-theme-tulip-lab/package.json
+++ b/slidev/packages/slidev-theme-tulip-lab/package.json
@@ -1,9 +1,18 @@
 {
   "name": "slidev-theme-tulip-lab",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "TULIP Lab theme for 16:10 Slidev courses and talks.",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tulip-lab/templatex.git",
+    "directory": "slidev/packages/slidev-theme-tulip-lab"
+  },
+  "bugs": {
+    "url": "https://github.com/tulip-lab/templatex/issues"
+  },
+  "homepage": "https://github.com/tulip-lab/templatex/tree/main/slidev/packages/slidev-theme-tulip-lab",
   "files": [
     "assets",
     "components",

--- a/slidev/packages/tulip-slidev-check/README.md
+++ b/slidev/packages/tulip-slidev-check/README.md
@@ -7,7 +7,7 @@ Shared structure and metadata checks for TULIP Slidev courses and talks.
 Install the checker in a deck and pin its exact version:
 
 ```sh
-pnpm add -D tulip-slidev-check@0.1.0-beta.1
+pnpm add -D tulip-slidev-check@0.1.0
 pnpm exec tulip-slidev-check --profile talk .
 ```
 

--- a/slidev/packages/tulip-slidev-check/package.json
+++ b/slidev/packages/tulip-slidev-check/package.json
@@ -1,9 +1,18 @@
 {
   "name": "tulip-slidev-check",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0",
   "description": "Structure and metadata checks for TULIP Slidev presentations.",
   "type": "module",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tulip-lab/templatex.git",
+    "directory": "slidev/packages/tulip-slidev-check"
+  },
+  "bugs": {
+    "url": "https://github.com/tulip-lab/templatex/issues"
+  },
+  "homepage": "https://github.com/tulip-lab/templatex/tree/main/slidev/packages/tulip-slidev-check",
   "bin": {
     "tulip-slidev-check": "./bin/tulip-slidev-check.mjs"
   },

--- a/slidev/packages/tulip-slidev-check/tests/check-deck.test.mjs
+++ b/slidev/packages/tulip-slidev-check/tests/check-deck.test.mjs
@@ -45,7 +45,7 @@ ${extraMarkdown}`
 
 const sharedDependencies = {
   '@slidev/cli': '52.19.0',
-  'slidev-theme-tulip-lab': '0.1.0-beta.1',
+  'slidev-theme-tulip-lab': '0.1.0',
   'vue': '3.5.41',
 }
 
@@ -100,7 +100,7 @@ test('reports geometry, structure, metadata, dependency, and image issues togeth
     canvasWidth: 1920,
     dependencies: {
       '@slidev/cli': '^52.19.0',
-      'slidev-theme-tulip-lab': '0.1.0-beta.1',
+      'slidev-theme-tulip-lab': '0.1.0',
     },
     extraMarkdown: `
 ![](./missing-alt.png)

--- a/slidev/scripts/check-workspace.mjs
+++ b/slidev/scripts/check-workspace.mjs
@@ -30,7 +30,7 @@ assert(root.private === true, 'The workspace root must remain private')
 for (const [path, name] of publicPackages) {
   const manifest = await readManifest(path)
   assert(manifest.name === name, `${path} has an unexpected package name`)
-  assert(manifest.version === '0.1.0-beta.1', `${name} must use the shared beta release version`)
+  assert(manifest.version === '0.1.0', `${name} must use the shared stable release version`)
   assert(manifest.license === 'MIT', `${name} must use the MIT licence`)
   assert(manifest.private !== true, `${name} must remain eligible for future publication`)
 }


### PR DESCRIPTION
Completes the Git Flow release by merging the stable 0.1.0 version metadata and public package links back into develop. The release candidate passed the full workspace suite and clean public-registry Course/Talk builds.